### PR TITLE
Fix month display in BookCard component.

### DIFF
--- a/src/components/BookCard.vue
+++ b/src/components/BookCard.vue
@@ -277,7 +277,9 @@ function iconClick(col: string) {
 function displayTimestamp(timestamp?: number): string {
   if (!timestamp) return '';
   const date = new Date(timestamp * 1000);
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  const month = date.getMonth() + 1;
+  const monthStr = month < 10 ? `0${month}` : String(month);
+  return `${date.getFullYear()}-${monthStr}-${date.getDate()}`;
 }
 
 function formattedDateRead(): string {


### PR DESCRIPTION
Modified the  function in  to format the month with two digits. This ensures that single-digit months (e.g., January) are displayed as "01" instead of "1".